### PR TITLE
Switch to getting LibUsbDotNet from NuGet

### DIFF
--- a/PlasmaSharpDriver/PlasmaSharpDriver.csproj
+++ b/PlasmaSharpDriver/PlasmaSharpDriver.csproj
@@ -31,9 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LibUsbDotNet, Version=2.2.8.104, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\LibUsbDotNet\LibUsbDotNet.dll</HintPath>
+    <Reference Include="LibUsbDotNet">
+      <HintPath>..\packages\LibUsbDotNet.2.2.8\lib\LibUsbDotNet.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -48,6 +47,9 @@
     <Compile Include="PlasmaTrimController.cs" />
     <Compile Include="PlasmaTrimState.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/PlasmaSharpDriver/packages.config
+++ b/PlasmaSharpDriver/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="LibUsbDotNet" version="2.2.8" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
It's unlikely people will have a copy of LibUsbDotNet in their Program Files folder. I suggest having Visual Studio pull it from NuGet instead.
